### PR TITLE
Mods to fix issue #53

### DIFF
--- a/app/src/main/java/com/launcher/silverfish/common/Constants.java
+++ b/app/src/main/java/com/launcher/silverfish/common/Constants.java
@@ -29,6 +29,6 @@ public class Constants {
 
     public final static String TAB_ID = "tab_id";
 
-    public final static int SCREEN_CORNER_THRESHOLD = 40;
-    public final static float NO_DRAG_THRESHOLD_SQ = 400f; // Squared distance (20² px)
+    public final static float DRAG_THRESHOLD_PERCENT_X = .95f;  // % of screen width
+    public final static float MIN_DRAG_ADJ = .75f;              // Apply to icon dimension
 }

--- a/app/src/main/java/com/launcher/silverfish/common/Constants.java
+++ b/app/src/main/java/com/launcher/silverfish/common/Constants.java
@@ -29,6 +29,6 @@ public class Constants {
 
     public final static String TAB_ID = "tab_id";
 
-    public final static float DRAG_THRESHOLD_PERCENT_X = .95f;  // % of screen width
-    public final static float MIN_DRAG_ADJ = .75f;              // Apply to icon dimension
+    public final static float DRAG_THRESHOLD_PERCENT_X = .95f;  // Percent of screen width
+    public final static float MIN_DRAG_ADJ = .75f;              // Percent of icon dimension
 }

--- a/app/src/main/java/com/launcher/silverfish/common/LG.java
+++ b/app/src/main/java/com/launcher/silverfish/common/LG.java
@@ -1,0 +1,63 @@
+package com.launcher.silverfish.common;
+
+import android.util.Log;
+
+/** Intelligent logger optionally provides calling class & method for the message. <br>
+ Standard usage: lg("any string");  [Will generate a TAG of Class.methodName ] <br>
+ @author Matt Arnold */
+public class LG {
+
+    private static boolean debug = false;
+    public static void setDebug(boolean debug) {LG.debug = debug;}
+    public static boolean isDebug() {return debug;}
+
+    private static boolean voluminous = false;
+    private void setVoluminous(boolean voluminous) {LG.voluminous = voluminous;}
+    private boolean isVoluminous() {return voluminous;}
+
+    private static final String regex_splitAtdot = "\\.";
+    /**
+     * Get the method name for a depth in call stack.
+     * @param depth depth in the call stack (0 means current method, 1 means call method, ...)
+     * @return method name
+     */
+    public static String getMethodNme(final int depth)
+    {
+        final StackTraceElement[] ste = Thread.currentThread().getStackTrace();
+        int rd = depth+2;
+        String[] Cfull = ste[rd].getClassName().split(regex_splitAtdot);
+        String Cname = Cfull[Cfull.length-1];       // Class
+        String Mname = ste[rd].getMethodName();     // Method
+        //lg("gmn2","depth="+ depth+":"+ Cname + "." + Mname);
+        return Cname + "." + Mname;
+    }
+
+    /** Universal non-voluminous logging */
+    public static void lg(String s2) {lg(getMethodNme(2),s2); }
+    /** Universal non-voluminous logging */
+    public static void lg(String s1, String s2) {
+        if (s1 == null || s1.isEmpty()) s1="U.lg() ???";
+        if (s2 == null || s2.isEmpty()) s2="!";
+        if (debug) Log.d(s1,s2);
+    }
+
+    /** Universal voluminous logging */
+    public static void lgV(String s2) {lgV(getMethodNme(2),s2); }
+    /** Universal voluminous logging */
+    public static void lgV(String s1, String s2) { if (voluminous) Log.d(s1,s2); }
+
+    /** Universal forced logging */
+    public static void lgF(String s2) {lgF(getMethodNme(2),s2); }
+    /** Universal forced logging */
+    public static void lgF(String s1, String s2) {Log.d(s1,s2); }
+
+    /** Universal forced exception logging */
+    public static void lgX(String s2) {lgX(getMethodNme(2),s2); }
+    /** Universal forced exception logging */
+    public static void lgX(String s1, String s2) {
+        if (s1 == null || s1.isEmpty()) s1="U.lgx() ???";
+        Log.e(s1,s2);
+    }
+}
+
+

--- a/app/src/main/java/com/launcher/silverfish/common/Utils.java
+++ b/app/src/main/java/com/launcher/silverfish/common/Utils.java
@@ -26,13 +26,24 @@ import android.graphics.drawable.Drawable;
 import android.os.AsyncTask;
 import android.util.Log;
 import android.view.Display;
+import android.view.DragEvent;
 import android.widget.ImageView;
+
+import java.lang.ref.WeakReference;
 
 /**
  * Created by Stanislav Pintjuk on 8/3/16.
  * E-mail: stanislav.pintjuk@gmail.com
  */
 public class Utils {
+
+    /**
+     * Is supplied drag event within the 'move to home page' zone?
+     */
+    public static boolean isBeyondRightHandThreshold(Activity a, DragEvent dragEvent) {
+        int xThreshold = Utils.getScreenDimensions(a).x - Constants.SCREEN_CORNER_THRESHOLD;
+        return (dragEvent.getX() > xThreshold);
+    }
 
     public static Point getScreenDimensions(Activity activity) {
         // Get the screen size
@@ -47,47 +58,57 @@ public class Utils {
         int screen_width = screensize.x;
         int screen_height = screensize.y;
         // Set the threshold to be 10% of the screen height
-        float thresholdx = 20.0f*screen_height/100.0f;
-        float thresholdy = 10.0f*screen_height/100.0f;
-        return (y >= screen_height - thresholdy && x <= screen_width - thresholdx && x >= 0+thresholdx);
+        float thresholdx = 20.0f * screen_height / 100.0f;
+        float thresholdy = 10.0f * screen_height / 100.0f;
+        return (y >= screen_height - thresholdy && x <= screen_width - thresholdx && x >= 0 + thresholdx);
     }
 
-    public static void loadAppIconAsync(final PackageManager pm, final String appInfo, final ImageView im ){
 
-        // Create an async task
-        AsyncTask<Void,Void,Drawable> loadAppIconTask = new AsyncTask<Void, Void, Drawable>() {
+    // 08Feb2018 Forced to rewrite as static subclass to satisfy Android Studio 3 stringencies!
+    // [Refer https://stackoverflow.com/a/46166223/2376004]
+    /** AsyncTask to render application icon: */
+    private static class loadAppIconTask extends AsyncTask<Void, Void, Drawable> {
+        private Exception exception = null;
+        private WeakReference<PackageManager> pm_wr;
+        private WeakReference<String> appInfo_wr;
+        private WeakReference<ImageView> iv_wr;
 
-            // Keep track of all the exceptions
-            private Exception exception = null;
+        // Constructor
+        loadAppIconTask(PackageManager pm, String appInfo, ImageView iv) {
+            pm_wr = new WeakReference<>(pm);
+            appInfo_wr = new WeakReference<>(appInfo);
+            iv_wr = new WeakReference<>(iv);
+        }
 
-
-            @Override
-            protected Drawable doInBackground(Void... voids) {
-                // load the icon
-                Drawable app_icon = null;
-                try {
-                    app_icon = pm.getApplicationIcon(appInfo);
-
-                } catch (PackageManager.NameNotFoundException e) {
-                    e.printStackTrace();
-                    exception = e;
-                }
-
-                return app_icon;
+        @Override
+        protected Drawable doInBackground(Void... voids) {
+            // load the icon
+            Drawable app_icon = null;
+            try {
+                PackageManager pm = pm_wr.get();
+                String appInfo = appInfo_wr.get();
+                if (pm==null || appInfo==null ) return null;
+                app_icon = pm.getApplicationIcon(appInfo);
+            } catch (PackageManager.NameNotFoundException e) {
+                e.printStackTrace();
+                exception = e;
             }
+            return app_icon;
+        }
 
-            @Override
-            protected void onPostExecute(Drawable app_icon){
-                if (exception == null) {
-                    im.setImageDrawable(app_icon);
-
-                } else {
-                    Log.d("Utils.loadAppIconAsync", "ERROR Could not load app icon.");
-
-                }
+        @Override
+        protected void onPostExecute(Drawable app_icon) {
+            ImageView iv = iv_wr.get();
+            if (exception == null && app_icon != null && iv != null) {
+                iv.setImageDrawable(app_icon);
+                //Log.d("Utils.loadAppIconTask", "Loaded icon for '"+appInfo_wr.get()+"' OK");
+            } else {
+                Log.d("Utils.loadAppIconTask", "ERROR Could not load app icon.");
             }
-        };
+        }
+    }
 
-        loadAppIconTask.execute(null,null,null);
+    public static void loadAppIconAsync(PackageManager pm, String appInfo, ImageView iv ){
+        new loadAppIconTask(pm, appInfo, iv).execute(null,null,null);
     }
 }

--- a/app/src/main/java/com/launcher/silverfish/launcher/appdrawer/AppArrayAdapter.java
+++ b/app/src/main/java/com/launcher/silverfish/launcher/appdrawer/AppArrayAdapter.java
@@ -24,6 +24,9 @@ import com.launcher.silverfish.shared.Settings;
 
 import java.util.List;
 
+import static com.launcher.silverfish.common.LG.lg;
+import static java.lang.String.format;
+
 /**
  * Created by stani on 2016-12-15.
  */
@@ -65,16 +68,24 @@ public class AppArrayAdapter extends ArrayAdapter<AppDetail> {
         //final TextView appLabel = (TextView) view.findViewById(R.id.item_app_label);
         viewHolder.appLabel.setText(app.label);
 
-        // Start a drag action when icon is long clicked
         view.setOnLongClickListener(new View.OnLongClickListener() {
             @Override
             public boolean onLongClick(View view) {
+                // Start a drag action with ClipData when icon is long clicked
+                lg(format("Icon long press for %s ('%s') tab=%s", app.packageName, app.label, mTag));
 
-                // Add data to the clipboard
+                // Add data to the clipboard ...
+                // Current ClipData.Item usage:
+                //     0: package eg: 'com.launcher.silverfish'
+                //     1: ArrayAdapter position eg: 0
+                //     2: Fragment tag eg: "1" to represent tab 'OTHER'
+                //     3: Application label eg: 'Silverfish'                10Feb2018
+                // CAUTION: This package uses hard-coded offsets to reference ClipData items. Fix!
                 String[] mime_type = {ClipDescription.MIMETYPE_TEXT_PLAIN};
                 ClipData data = new ClipData(Constants.DRAG_APP_MOVE, mime_type, new ClipData.Item(app.packageName.toString()));
                 data.addItem(new ClipData.Item(Integer.toString(position)));
                 data.addItem(new ClipData.Item(mTag));
+                data.addItem(new ClipData.Item(app.label.toString()));
 
                 // The drag shadow is simply the app's  icon
                 View.DragShadowBuilder shadowBuilder = new View.DragShadowBuilder(

--- a/app/src/main/java/com/launcher/silverfish/launcher/settings/SettingsScreenFragment.java
+++ b/app/src/main/java/com/launcher/silverfish/launcher/settings/SettingsScreenFragment.java
@@ -8,12 +8,16 @@ import android.support.v4.app.Fragment;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.Button;
 import android.widget.Toast;
 
 import com.launcher.silverfish.R;
+import com.launcher.silverfish.common.LG;
 import com.launcher.silverfish.shared.Settings;
 
 import yuku.ambilwarna.AmbilWarnaDialog;
+
+import static com.launcher.silverfish.common.LG.lg;
 
 public class SettingsScreenFragment extends Fragment  {
 
@@ -38,14 +42,16 @@ public class SettingsScreenFragment extends Fragment  {
 
     @Override
     public void onCreate(@Nullable Bundle savedInstanceState) {
+        lg("Method begins...");
         super.onCreate(savedInstanceState);
+
         settings = new Settings(getContext());
     }
 
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
-
+        lg("Method begins...");
         View rootView = inflater.inflate(R.layout.activity_settings, container, false);
 
         // Toggle widget visibility button
@@ -101,6 +107,16 @@ public class SettingsScreenFragment extends Fragment  {
                         changeFontColor();
                     }
                 });
+
+        // Enable debug logging
+        Button toggle_logging = (Button)rootView.findViewById(R.id.toggle_logging);
+        syncLogging(toggle_logging);    // Set (dynamic) button text
+        toggle_logging.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                toggleLogging((Button)view);
+            }
+        });
 
         return rootView;
     }
@@ -176,6 +192,15 @@ public class SettingsScreenFragment extends Fragment  {
                     }
                 }).show();
     }
+
+    private void toggleLogging(Button btn) {
+        LG.setDebug(!LG.isDebug());         // Toggle on/off
+        syncLogging(btn);                   // Synchronise button text
+    }
+    private void syncLogging(Button btn) {
+        btn.setText(LG.isDebug() ? R.string.text_debug_off : R.string.text_debug_on);
+    }
+
 
     //endregion
 

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -139,4 +139,39 @@
             android:textColor="@color/white"
             android:layout_weight="1"/>
     </LinearLayout>
+
+    <!-- Developer Options -->
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingLeft="16dp"
+        android:paddingStart="16dp"
+        android:paddingEnd="16dp"
+        android:layout_margin="4dp"
+        android:text="@string/text_developer"
+        android:textAppearance="?android:textAppearanceLarge"
+        android:gravity="start"
+        android:textColor="@color/white"/>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
+
+        <Button
+            android:id="@+id/toggle_logging"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:padding="8dp"
+            android:layout_margin="4dp"
+            android:text="@string/text_debug_on"
+            android:background="@drawable/tintbackground"
+            android:textAppearance="?android:textAppearanceSmall"
+            style="?buttonBarButtonStyle"
+            android:gravity="center_vertical"
+            android:textColor="@color/white"
+            android:layout_weight="1"/>
+
+
+    </LinearLayout>
 </LinearLayout>

--- a/app/src/main/res/values-sw768dp/dimens.xml
+++ b/app/src/main/res/values-sw768dp/dimens.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources><dimen name="app_icon_size">72dp</dimen></resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -35,7 +35,7 @@
     <string name="text_wallpaper">Wallpaper</string>
     <string name="text_font">Font</string>
 
-    <string name="text_developer">Developer Options</string>
+    <string name="text_developer">Developer options</string>
     <string name="text_debug_off">Turn logging OFF</string>
     <string name="text_debug_on">Turn logging ON</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -35,6 +35,10 @@
     <string name="text_wallpaper">Wallpaper</string>
     <string name="text_font">Font</string>
 
+    <string name="text_developer">Developer Options</string>
+    <string name="text_debug_off">Turn logging OFF</string>
+    <string name="text_debug_on">Turn logging ON</string>
+
     <string name="setting_toggle_visibility">Toggle visibility</string>
     <string name="setting_change_widget">Change widget</string>
     <string name="setting_select_wallpaper">Select wallpaper</string>
@@ -43,5 +47,7 @@
     <string name="hint_widget_now_visible">The widget is now visible.</string>
     <string name="hint_widget_now_invisible">The widget has been hidden.</string>
     <string name="add_to_home_screen">Add to home screen</string>
+    <string name="remove_shortcut">Remove shortcut</string>
+    <string name="go_to_app_settings">App settings</string>
     <string name="application_not_installed">The application is not installed</string>
 </resources>


### PR DESCRIPTION
_TabbedAppDrawerFragment.java_ now has code that moves a dragged item to the home page once it reaches the far right hand side of the screen. (The exact threshold being determined by a new method in _common.Utils_)  

If the icon is dragged minimally the pop-up menu is triggered allowing user to achieve the same thing.

Because I run (Win10) Android Studio 3 I was forced to rewrite _common.Utils.loadAppIconAsync()_ to be fully static. (Github would not accept otherwise) See the stackoverflow question documented in the code.  

Finally I added a new resource to give a larger Icon size on tablets.  

I apologize for the apparent volume of changes - for some reason AS took it upon itself to apply a lot of minor formatting changes!!!!  

Have tested on Samsung Galaxy S3 handheld and Samsung Galaxy Tab S2 tablet. 