### PR TITLE
Fixes #68

### DIFF
--- a/app/src/main/java/com/launcher/silverfish/common/Utils.java
+++ b/app/src/main/java/com/launcher/silverfish/common/Utils.java
@@ -20,13 +20,18 @@
 package com.launcher.silverfish.common;
 
 import android.app.Activity;
+import android.content.ComponentName;
+import android.content.Intent;
 import android.content.pm.PackageManager;
+import android.content.pm.ResolveInfo;
 import android.graphics.Point;
 import android.graphics.drawable.Drawable;
 import android.os.AsyncTask;
 import android.util.Log;
 import android.view.Display;
 import android.widget.ImageView;
+
+import com.launcher.silverfish.models.AppDetail;
 
 /**
  * Created by Stanislav Pintjuk on 8/3/16.
@@ -52,7 +57,7 @@ public class Utils {
         return (y >= screen_height - thresholdy && x <= screen_width - thresholdx && x >= 0+thresholdx);
     }
 
-    public static void loadAppIconAsync(final PackageManager pm, final String appInfo, final ImageView im ){
+    public static void loadAppIconAsync(final PackageManager packageManager, final AppDetail appDetail, final ImageView im) {
 
         // Create an async task
         AsyncTask<Void,Void,Drawable> loadAppIconTask = new AsyncTask<Void, Void, Drawable>() {
@@ -65,15 +70,10 @@ public class Utils {
             protected Drawable doInBackground(Void... voids) {
                 // load the icon
                 Drawable app_icon = null;
-                try {
-                    app_icon = pm.getApplicationIcon(appInfo);
-
-                } catch (PackageManager.NameNotFoundException e) {
-                    e.printStackTrace();
-                    exception = e;
-                }
-
-                return app_icon;
+                Intent intent = new Intent();
+                intent.setComponent(new ComponentName(appDetail.packageName.toString(), appDetail.activityName.toString()));
+                ResolveInfo resolveInfo = packageManager.resolveActivity(intent, 0);
+                return resolveInfo.loadIcon(packageManager);
             }
 
             @Override

--- a/app/src/main/java/com/launcher/silverfish/common/Utils.java
+++ b/app/src/main/java/com/launcher/silverfish/common/Utils.java
@@ -69,10 +69,9 @@ public class Utils {
             @Override
             protected Drawable doInBackground(Void... voids) {
                 // load the icon
-                Drawable app_icon = null;
                 Intent intent = new Intent();
                 intent.setComponent(new ComponentName(appDetail.packageName.toString(), appDetail.activityName.toString()));
-                ResolveInfo resolveInfo = packageManager.resolveActivity(intent, 0);
+                ResolveInfo resolveInfo = packageManager.resolveActivity(intent, PackageManager.GET_META_DATA);
                 return resolveInfo.loadIcon(packageManager);
             }
 

--- a/app/src/main/java/com/launcher/silverfish/dbmodel/AppTable.java
+++ b/app/src/main/java/com/launcher/silverfish/dbmodel/AppTable.java
@@ -3,12 +3,9 @@ package com.launcher.silverfish.dbmodel;
 import org.greenrobot.greendao.annotation.Entity;
 import org.greenrobot.greendao.annotation.Generated;
 import org.greenrobot.greendao.annotation.Id;
-import org.greenrobot.greendao.annotation.Index;
 import org.greenrobot.greendao.annotation.NotNull;
 
-@Entity(indexes = {
-        @Index(value = "activityName", unique = true)
-})
+@Entity()
 public class AppTable {
     @Id(autoincrement = true)
     private Long id;

--- a/app/src/main/java/com/launcher/silverfish/dbmodel/AppTable.java
+++ b/app/src/main/java/com/launcher/silverfish/dbmodel/AppTable.java
@@ -22,7 +22,7 @@ public class AppTable {
     @NotNull
     private Long tabId;
 
-    @Generated
+    @Generated(hash = 1498711068)
     public AppTable(Long id, @NotNull String packageName, @NotNull String activityName, @NotNull Long tabId) {
         this.id = id;
         this.packageName = packageName;
@@ -30,7 +30,7 @@ public class AppTable {
         this.tabId = tabId;
     }
 
-    @Generated
+    @Generated(hash = 639376780)
     public AppTable() {
     }
 

--- a/app/src/main/java/com/launcher/silverfish/dbmodel/AppTable.java
+++ b/app/src/main/java/com/launcher/silverfish/dbmodel/AppTable.java
@@ -1,13 +1,13 @@
 package com.launcher.silverfish.dbmodel;
 
 import org.greenrobot.greendao.annotation.Entity;
+import org.greenrobot.greendao.annotation.Generated;
 import org.greenrobot.greendao.annotation.Id;
 import org.greenrobot.greendao.annotation.Index;
 import org.greenrobot.greendao.annotation.NotNull;
-import org.greenrobot.greendao.annotation.Generated;
 
 @Entity(indexes = {
-        @Index(value = "packageName", unique = true)
+        @Index(value = "activityName", unique = true)
 })
 public class AppTable {
     @Id(autoincrement = true)
@@ -15,18 +15,22 @@ public class AppTable {
 
     @NotNull
     private String packageName;
+    @NotNull
+    private String activityName;
+
 
     @NotNull
     private Long tabId;
 
-    @Generated(hash = 1161766823)
-    public AppTable(Long id, @NotNull String packageName, @NotNull Long tabId) {
+    @Generated
+    public AppTable(Long id, @NotNull String packageName, @NotNull String activityName, @NotNull Long tabId) {
         this.id = id;
         this.packageName = packageName;
+        this.activityName = activityName;
         this.tabId = tabId;
     }
 
-    @Generated(hash = 639376780)
+    @Generated
     public AppTable() {
     }
 
@@ -52,5 +56,13 @@ public class AppTable {
 
     public void setTabId(Long tabId) {
         this.tabId = tabId;
+    }
+
+    public String getActivityName() {
+        return activityName;
+    }
+
+    public void setActivityName(String activityName) {
+        this.activityName = activityName;
     }
 }

--- a/app/src/main/java/com/launcher/silverfish/dbmodel/ShortcutTable.java
+++ b/app/src/main/java/com/launcher/silverfish/dbmodel/ShortcutTable.java
@@ -18,14 +18,14 @@ public class ShortcutTable {
     private String activityName;
 
 
-    @Generated
+    @Generated(hash = 336387105)
     public ShortcutTable(Long id, @NotNull String packageName, @NotNull String activityName) {
         this.id = id;
         this.packageName = packageName;
         this.activityName = activityName;
     }
 
-    @Generated
+    @Generated(hash = 2116092840)
     public ShortcutTable() {
     }
 

--- a/app/src/main/java/com/launcher/silverfish/dbmodel/ShortcutTable.java
+++ b/app/src/main/java/com/launcher/silverfish/dbmodel/ShortcutTable.java
@@ -3,12 +3,9 @@ package com.launcher.silverfish.dbmodel;
 import org.greenrobot.greendao.annotation.Entity;
 import org.greenrobot.greendao.annotation.Generated;
 import org.greenrobot.greendao.annotation.Id;
-import org.greenrobot.greendao.annotation.Index;
 import org.greenrobot.greendao.annotation.NotNull;
 
-@Entity(indexes = {
-        @Index(value = "activityName", unique = true)
-})
+@Entity()
 public class ShortcutTable {
     @Id(autoincrement = true)
     private Long id;
@@ -16,13 +13,14 @@ public class ShortcutTable {
     private String packageName;
     @NotNull
     private String activityName;
+    private String intentUri;
 
-
-    @Generated(hash = 336387105)
-    public ShortcutTable(Long id, @NotNull String packageName, @NotNull String activityName) {
+    @Generated(hash = 1114900044)
+    public ShortcutTable(Long id, @NotNull String packageName, @NotNull String activityName, String intentUri) {
         this.id = id;
         this.packageName = packageName;
         this.activityName = activityName;
+        this.intentUri = intentUri;
     }
 
     @Generated(hash = 2116092840)
@@ -51,5 +49,13 @@ public class ShortcutTable {
 
     public void setActivityName(String activityName) {
         this.activityName = activityName;
+    }
+
+    public String getIntentUri() {
+        return intentUri;
+    }
+
+    public void setIntentUri(String intentUri) {
+        this.intentUri = intentUri;
     }
 }

--- a/app/src/main/java/com/launcher/silverfish/dbmodel/ShortcutTable.java
+++ b/app/src/main/java/com/launcher/silverfish/dbmodel/ShortcutTable.java
@@ -1,28 +1,31 @@
 package com.launcher.silverfish.dbmodel;
 
 import org.greenrobot.greendao.annotation.Entity;
+import org.greenrobot.greendao.annotation.Generated;
 import org.greenrobot.greendao.annotation.Id;
 import org.greenrobot.greendao.annotation.Index;
 import org.greenrobot.greendao.annotation.NotNull;
-import org.greenrobot.greendao.annotation.Generated;
 
 @Entity(indexes = {
-        @Index(value = "packageName", unique = true)
+        @Index(value = "activityName", unique = true)
 })
 public class ShortcutTable {
     @Id(autoincrement = true)
     private Long id;
-
     @NotNull
     private String packageName;
+    @NotNull
+    private String activityName;
 
-    @Generated(hash = 368591881)
-    public ShortcutTable(Long id, @NotNull String packageName) {
+
+    @Generated
+    public ShortcutTable(Long id, @NotNull String packageName, @NotNull String activityName) {
         this.id = id;
         this.packageName = packageName;
+        this.activityName = activityName;
     }
 
-    @Generated(hash = 2116092840)
+    @Generated
     public ShortcutTable() {
     }
 
@@ -40,5 +43,13 @@ public class ShortcutTable {
 
     public void setPackageName(String packageName) {
         this.packageName = packageName;
+    }
+
+    public String getActivityName() {
+        return activityName;
+    }
+
+    public void setActivityName(String activityName) {
+        this.activityName = activityName;
     }
 }

--- a/app/src/main/java/com/launcher/silverfish/launcher/LauncherActivity.java
+++ b/app/src/main/java/com/launcher/silverfish/launcher/LauncherActivity.java
@@ -26,7 +26,6 @@ import android.content.pm.ResolveInfo;
 import android.os.Bundle;
 import android.support.v4.app.FragmentActivity;
 import android.support.v4.view.ViewPager;
-import android.util.Log;
 import android.view.DragEvent;
 import android.view.KeyEvent;
 import android.view.View;
@@ -34,10 +33,10 @@ import android.view.View;
 import com.launcher.silverfish.R;
 import com.launcher.silverfish.common.Constants;
 import com.launcher.silverfish.common.Utils;
+import com.launcher.silverfish.dbmodel.AppTable;
 import com.launcher.silverfish.launcher.homescreen.HomeScreenFragment;
 import com.launcher.silverfish.launcher.homescreen.ShortcutAddListener;
 import com.launcher.silverfish.launcher.settings.SettingsScreenFragment;
-import com.launcher.silverfish.shared.Settings;
 import com.launcher.silverfish.sqlite.LauncherSQLiteHelper;
 import com.launcher.silverfish.utils.PackagesCategories;
 
@@ -130,7 +129,7 @@ public class LauncherActivity extends FragmentActivity
 
         // Store here the packages and their categories IDs
         // This will allow us to add all the apps at once instead opening the database over and over
-        HashMap<String, Long> pkg_categoryId =
+        HashMap<AppTable, Long> pkg_categoryId =
                 PackagesCategories.setCategories(getApplicationContext(), availableActivities);
 
         // Then add all the apps to their corresponding tabs at once

--- a/app/src/main/java/com/launcher/silverfish/launcher/LauncherActivity.java
+++ b/app/src/main/java/com/launcher/silverfish/launcher/LauncherActivity.java
@@ -159,9 +159,9 @@ public class LauncherActivity extends FragmentActivity
         return (HomeScreenFragment)mCollectionPagerAdapter.instantiateItem(mViewPager, 1);
     }
 
-    public boolean addShortcut(String appName) {
+    public boolean addShortcut(AppTable appTable) {
         if (getFragShortcutAddListenerRefreshListener() != null) {
-            getFragShortcutAddListenerRefreshListener().OnShortcutAdd(appName);
+            getFragShortcutAddListenerRefreshListener().OnShortcutAdd(appTable);
             return true;
         }
         else
@@ -220,8 +220,10 @@ public class LauncherActivity extends FragmentActivity
 
     private void dropItem(DragEvent dragEvent) {
         if (mViewPager.getCurrentItem() == 1) {
-            String appName = dragEvent.getClipData().getItemAt(0).getText().toString();
-            addShortcut(appName);
+            AppTable appTable = new AppTable();
+            appTable.setPackageName(dragEvent.getClipData().getItemAt(0).getText().toString());
+            appTable.setActivityName(dragEvent.getClipData().getItemAt(1).getText().toString());
+            addShortcut(appTable);
         }
     }
 

--- a/app/src/main/java/com/launcher/silverfish/launcher/LauncherActivity.java
+++ b/app/src/main/java/com/launcher/silverfish/launcher/LauncherActivity.java
@@ -40,7 +40,6 @@ import com.launcher.silverfish.launcher.settings.SettingsScreenFragment;
 import com.launcher.silverfish.sqlite.LauncherSQLiteHelper;
 import com.launcher.silverfish.utils.PackagesCategories;
 
-import java.util.HashMap;
 import java.util.List;
 
 /**
@@ -125,15 +124,13 @@ public class LauncherActivity extends FragmentActivity
 
         // Get all activities that have those filters
         List<ResolveInfo> availableActivities = mPacMan.queryIntentActivities(i, 0);
-
-
         // Store here the packages and their categories IDs
         // This will allow us to add all the apps at once instead opening the database over and over
-        HashMap<AppTable, Long> pkg_categoryId =
-                PackagesCategories.setCategories(getApplicationContext(), availableActivities);
+        List<AppTable> apps =
+                PackagesCategories.setCategoriesForAppTable(getApplicationContext(), availableActivities);
 
         // Then add all the apps to their corresponding tabs at once
-        sql.addAppsToTab(pkg_categoryId);
+        sql.addAppsToTab(apps);
     }
 
     //endregion

--- a/app/src/main/java/com/launcher/silverfish/launcher/LauncherReceiver.java
+++ b/app/src/main/java/com/launcher/silverfish/launcher/LauncherReceiver.java
@@ -16,6 +16,7 @@ public class LauncherReceiver extends BroadcastReceiver {
     public void onReceive(Context context, Intent intent) {
         if (intent.getAction().equals(INSTALL_SHORTCUT)) {
             Intent target = intent.getParcelableExtra(Intent.EXTRA_SHORTCUT_INTENT);
+
             if (target == null)
                 return; // No target, do nothing
 
@@ -28,10 +29,11 @@ public class LauncherReceiver extends BroadcastReceiver {
             // TODO Save 'target.toUri(0)' instead, to preserve all the information
             final LauncherSQLiteHelper sql =
                     new LauncherSQLiteHelper((App)context.getApplicationContext());
-            // TODO: IMPORTANT! canAddShortcut uses activityName field to search.
-            //       Will cause NullPointerException.
-            // TODO: IMPORTANT! Figure out how to get activityName from here.
-            ShortcutTable shortcutTable = new ShortcutTable(null, target.getPackage(), null);
+
+            String intentUri = target.toUri(Intent.URI_INTENT_SCHEME);
+            ShortcutTable shortcutTable = new ShortcutTable(null,
+                    target.getComponent().getPackageName(),
+                    target.getComponent().getClassName(), intentUri);
             if (sql.canAddShortcut(shortcutTable))
                 sql.addShortcut(shortcutTable);
         }

--- a/app/src/main/java/com/launcher/silverfish/launcher/LauncherReceiver.java
+++ b/app/src/main/java/com/launcher/silverfish/launcher/LauncherReceiver.java
@@ -4,6 +4,7 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 
+import com.launcher.silverfish.dbmodel.ShortcutTable;
 import com.launcher.silverfish.sqlite.LauncherSQLiteHelper;
 
 public class LauncherReceiver extends BroadcastReceiver {
@@ -27,9 +28,12 @@ public class LauncherReceiver extends BroadcastReceiver {
             // TODO Save 'target.toUri(0)' instead, to preserve all the information
             final LauncherSQLiteHelper sql =
                     new LauncherSQLiteHelper((App)context.getApplicationContext());
-
-            if (sql.canAddShortcut(target.getPackage()))
-                sql.addShortcut(target.getPackage());
+            // TODO: IMPORTANT! canAddShortcut uses activityName field to search.
+            //       Will cause NullPointerException.
+            // TODO: IMPORTANT! Figure out how to get activityName from here.
+            ShortcutTable shortcutTable = new ShortcutTable(null, target.getPackage(), null);
+            if (sql.canAddShortcut(shortcutTable))
+                sql.addShortcut(shortcutTable);
         }
     }
 }

--- a/app/src/main/java/com/launcher/silverfish/launcher/PackageModifiedReceiver.java
+++ b/app/src/main/java/com/launcher/silverfish/launcher/PackageModifiedReceiver.java
@@ -25,6 +25,8 @@ public class PackageModifiedReceiver extends BroadcastReceiver {
                 if (added) {
                     // TODO Determine its category
                 } else {
+                    // TODO: ShortcutTable entries are no longer uniquely identified by its packageName.
+                    // Also take in to account activityName and intentUri
                     final long id = sql.getShortcutId(pkg);
                     sql.removeShortcut(id);
                     if (app.shortcutListener != null)

--- a/app/src/main/java/com/launcher/silverfish/launcher/appdrawer/AppArrayAdapter.java
+++ b/app/src/main/java/com/launcher/silverfish/launcher/appdrawer/AppArrayAdapter.java
@@ -21,6 +21,7 @@ import com.launcher.silverfish.common.Utils;
 import com.launcher.silverfish.models.AppDetail;
 import com.launcher.silverfish.shared.Settings;
 
+import java.net.URISyntaxException;
 import java.util.List;
 
 /**
@@ -98,8 +99,16 @@ public class AppArrayAdapter extends ArrayAdapter<AppDetail> {
             @Override
             public void onClick(View view) {
                 Intent i = new Intent();
-                i.setAction(Intent.ACTION_MAIN);
-                i.setComponent(new ComponentName(app.packageName.toString(), app.activityName.toString()));
+                if (app.intentUri != null) {
+                    try {
+                        i = Intent.parseUri(app.intentUri.toString(), Intent.URI_INTENT_SCHEME);
+                    } catch (URISyntaxException e) {
+                        e.printStackTrace();
+                    }
+                } else {
+                    i.setAction(Intent.ACTION_MAIN);
+                    i.setComponent(new ComponentName(app.packageName.toString(), app.activityName.toString()));
+                }
                 if (i != null) {
                     // Sanity check (application may have been uninstalled)
                     // TODO Remove it from the database

--- a/app/src/main/java/com/launcher/silverfish/launcher/appdrawer/AppArrayAdapter.java
+++ b/app/src/main/java/com/launcher/silverfish/launcher/appdrawer/AppArrayAdapter.java
@@ -72,6 +72,7 @@ public class AppArrayAdapter extends ArrayAdapter<AppDetail> {
                 // Add data to the clipboard
                 String[] mime_type = {ClipDescription.MIMETYPE_TEXT_PLAIN};
                 ClipData data = new ClipData(Constants.DRAG_APP_MOVE, mime_type, new ClipData.Item(app.packageName.toString()));
+                data.addItem(new ClipData.Item(app.activityName.toString()));
                 data.addItem(new ClipData.Item(Integer.toString(position)));
                 data.addItem(new ClipData.Item(mTag));
 

--- a/app/src/main/java/com/launcher/silverfish/launcher/appdrawer/AppArrayAdapter.java
+++ b/app/src/main/java/com/launcher/silverfish/launcher/appdrawer/AppArrayAdapter.java
@@ -59,7 +59,7 @@ public class AppArrayAdapter extends ArrayAdapter<AppDetail> {
         }
 
         // load the app icon in an async task
-        Utils.loadAppIconAsync(mPackageManager, app.packageName.toString(), viewHolder.appIcon);
+        Utils.loadAppIconAsync(mPackageManager, app, viewHolder.appIcon);
 
         //final TextView appLabel = (TextView) view.findViewById(R.id.item_app_label);
         viewHolder.appLabel.setText(app.label);

--- a/app/src/main/java/com/launcher/silverfish/launcher/appdrawer/AppArrayAdapter.java
+++ b/app/src/main/java/com/launcher/silverfish/launcher/appdrawer/AppArrayAdapter.java
@@ -3,12 +3,11 @@ package com.launcher.silverfish.launcher.appdrawer;
 import android.app.Activity;
 import android.content.ClipData;
 import android.content.ClipDescription;
+import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
-import android.graphics.Rect;
 import android.os.Build;
-import android.util.Log;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ArrayAdapter;
@@ -97,7 +96,9 @@ public class AppArrayAdapter extends ArrayAdapter<AppDetail> {
         view.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                Intent i = mPackageManager.getLaunchIntentForPackage(app.packageName.toString());
+                Intent i = new Intent();
+                i.setAction(Intent.ACTION_MAIN);
+                i.setComponent(new ComponentName(app.packageName.toString(), app.activityName.toString()));
                 if (i != null) {
                     // Sanity check (application may have been uninstalled)
                     // TODO Remove it from the database

--- a/app/src/main/java/com/launcher/silverfish/launcher/appdrawer/AppDrawerTabFragment.java
+++ b/app/src/main/java/com/launcher/silverfish/launcher/appdrawer/AppDrawerTabFragment.java
@@ -119,11 +119,11 @@ public class AppDrawerTabFragment extends Fragment {
             AppDetail appDetail = new AppDetail();
 
             // And add it to the list.
+            // TODO: Possible source of bug! Doesn't take into account activityName when getting label.
             appDetail.label = mPacMan.getApplicationLabel(appInfo);
             appDetail.icon = null; // Loaded later by AppArrayAdapter
             appDetail.packageName = appTable.getPackageName();
             appDetail.activityName = appTable.getActivityName();
-            Log.d("fzn", appDetail.label + ";" + appDetail.packageName + ";" + appDetail.activityName);
             appsList.add(appDetail);
 
             hideEmptyCategoryNotice();

--- a/app/src/main/java/com/launcher/silverfish/launcher/appdrawer/AppDrawerTabFragment.java
+++ b/app/src/main/java/com/launcher/silverfish/launcher/appdrawer/AppDrawerTabFragment.java
@@ -20,8 +20,9 @@
 
 package com.launcher.silverfish.launcher.appdrawer;
 
+import android.content.ComponentName;
 import android.content.Intent;
-import android.content.pm.ApplicationInfo;
+import android.content.pm.ActivityInfo;
 import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
 import android.os.Bundle;
@@ -101,26 +102,27 @@ public class AppDrawerTabFragment extends Fragment {
     //region Adding applications
 
     public void addApp(AppTable appTable) {
+        appTable.setTabId(tabId);
         boolean success = addAppToList(appTable);
         if (success) {
             sortAppsList();
             arrayAdapter.notifyDataSetChanged();
             // add to database only if it is not the first tab
             if (tabId != 1)
-                sqlHelper.addAppToTab(appTable, tabId);
+                sqlHelper.addAppToTab(appTable);
         }
     }
 
     private boolean addAppToList(AppTable appTable) {
         try {
             // Get the information about the app
-            ApplicationInfo appInfo = mPacMan.getApplicationInfo(
-                    appTable.getPackageName(), PackageManager.GET_META_DATA);
+            ActivityInfo activityInfo = mPacMan.getActivityInfo(
+                    new ComponentName(appTable.getPackageName(), appTable.getActivityName()),
+                    PackageManager.GET_META_DATA);
             AppDetail appDetail = new AppDetail();
 
             // And add it to the list.
-            // TODO: Possible source of bug! Doesn't take into account activityName when getting label.
-            appDetail.label = mPacMan.getApplicationLabel(appInfo);
+            appDetail.label = activityInfo.loadLabel(mPacMan).toString();
             appDetail.icon = null; // Loaded later by AppArrayAdapter
             appDetail.packageName = appTable.getPackageName();
             appDetail.activityName = appTable.getActivityName();
@@ -176,7 +178,7 @@ public class AppDrawerTabFragment extends Fragment {
                 for (int j = 0; j < availableActivities.size(); j++)    {
                     ResolveInfo ri = availableActivities.get(j);
 
-                    if (sqlHelper.containsApp(ri.activityInfo.packageName))
+                    if (sqlHelper.containsApp(ri.activityInfo.name))
                         continue;
 
                     AppDetail app = new AppDetail();

--- a/app/src/main/java/com/launcher/silverfish/launcher/appdrawer/AppDrawerTabFragment.java
+++ b/app/src/main/java/com/launcher/silverfish/launcher/appdrawer/AppDrawerTabFragment.java
@@ -123,6 +123,7 @@ public class AppDrawerTabFragment extends Fragment {
             appDetail.icon = null; // Loaded later by AppArrayAdapter
             appDetail.packageName = appTable.getPackageName();
             appDetail.activityName = appTable.getActivityName();
+            Log.d("fzn", appDetail.label + ";" + appDetail.packageName + ";" + appDetail.activityName);
             appsList.add(appDetail);
 
             hideEmptyCategoryNotice();

--- a/app/src/main/java/com/launcher/silverfish/launcher/appdrawer/TabFragmentHandler.java
+++ b/app/src/main/java/com/launcher/silverfish/launcher/appdrawer/TabFragmentHandler.java
@@ -340,16 +340,16 @@ public class TabFragmentHandler {
             right.rename(leftName);
 
             // And now swap the applications by updating their category
-            Map<String, Long> leftApps = new HashMap<>();
+            Map<AppTable, Long> leftApps = new HashMap<>();
             for (AppTable app : sql.getAppsForTab(left.getId())) {
                 long category = rightIndex + 1; // Categories start one over
-                leftApps.put(app.getPackageName(), category);
+                leftApps.put(app, category);
             }
 
-            Map<String, Long> rightApps = new HashMap<>();
+            Map<AppTable, Long> rightApps = new HashMap<>();
             for (AppTable app : sql.getAppsForTab(right.getId())) {
                 long category = leftIndex + 1; // Categories start one over
-                rightApps.put(app.getPackageName(), category);
+                rightApps.put(app, category);
             }
 
             // First remove the apps from their original tab, we don't want duplicates!

--- a/app/src/main/java/com/launcher/silverfish/launcher/appdrawer/TabFragmentHandler.java
+++ b/app/src/main/java/com/launcher/silverfish/launcher/appdrawer/TabFragmentHandler.java
@@ -40,9 +40,7 @@ import com.launcher.silverfish.shared.Settings;
 import com.launcher.silverfish.sqlite.LauncherSQLiteHelper;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 /**
  * Created by Stanislav Pintjuk on 8/12/16.
@@ -340,16 +338,18 @@ public class TabFragmentHandler {
             right.rename(leftName);
 
             // And now swap the applications by updating their category
-            Map<AppTable, Long> leftApps = new HashMap<>();
+            List<AppTable> leftApps = new ArrayList<>();
             for (AppTable app : sql.getAppsForTab(left.getId())) {
                 long category = rightIndex + 1; // Categories start one over
-                leftApps.put(app, category);
+                app.setTabId(category);
+                leftApps.add(app);
             }
 
-            Map<AppTable, Long> rightApps = new HashMap<>();
+            List<AppTable> rightApps = new ArrayList<>();
             for (AppTable app : sql.getAppsForTab(right.getId())) {
                 long category = leftIndex + 1; // Categories start one over
-                rightApps.put(app, category);
+                app.setTabId(category);
+                rightApps.add(app);
             }
 
             // First remove the apps from their original tab, we don't want duplicates!

--- a/app/src/main/java/com/launcher/silverfish/launcher/appdrawer/TabbedAppDrawerFragment.java
+++ b/app/src/main/java/com/launcher/silverfish/launcher/appdrawer/TabbedAppDrawerFragment.java
@@ -22,13 +22,11 @@ package com.launcher.silverfish.launcher.appdrawer;
 import android.content.ClipDescription;
 import android.content.DialogInterface;
 import android.content.Intent;
-import android.net.LinkAddress;
 import android.net.Uri;
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
 import android.support.v7.app.AlertDialog;
 import android.text.InputType;
-import android.util.Log;
 import android.view.DragEvent;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -41,6 +39,7 @@ import android.widget.Toast;
 import com.launcher.silverfish.R;
 import com.launcher.silverfish.common.Constants;
 import com.launcher.silverfish.common.Utils;
+import com.launcher.silverfish.dbmodel.AppTable;
 import com.launcher.silverfish.launcher.LauncherActivity;
 import com.launcher.silverfish.models.TabInfo;
 
@@ -337,7 +336,8 @@ public class TabbedAppDrawerFragment extends Fragment {
 
                                 // add it to the new tab
                                 String app_name = dragEvent.getClipData().getItemAt(0).getText().toString();
-                                dropAppInTab(app_name);
+                                //TODO: IMPORTANT. Fix this line.
+                                //dropAppInTab(app_name);
                             }
                         }
                         break;
@@ -400,14 +400,14 @@ public class TabbedAppDrawerFragment extends Fragment {
         fragment.removeApp(appIndex);
     }
 
-    private void dropAppInTab(String app_name) {
+    private void dropAppInTab(AppTable appTable) {
         // Retrieve tab fragment
         android.support.v4.app.FragmentManager fm = getChildFragmentManager();
         TabInfo tab = tabHandler.getCurrentTab();
         AppDrawerTabFragment fragment = (AppDrawerTabFragment)fm.findFragmentByTag(tab.getTag());
 
         // Add app and refresh the tab's layout
-        fragment.addApp(app_name);
+        fragment.addApp(appTable);
     }
 
     //endregion

--- a/app/src/main/java/com/launcher/silverfish/launcher/appdrawer/TabbedAppDrawerFragment.java
+++ b/app/src/main/java/com/launcher/silverfish/launcher/appdrawer/TabbedAppDrawerFragment.java
@@ -326,18 +326,19 @@ public class TabbedAppDrawerFragment extends Fragment {
                             } else {
                                 // Retrieve tha drop information  and remove it from the original tab
                                 int appIndex = Integer.parseInt(
-                                        dragEvent.getClipData().getItemAt(1).
+                                        dragEvent.getClipData().getItemAt(2).
                                                 getText().toString());
 
-                                String tabTag = dragEvent.getClipData().getItemAt(2)
+                                String tabTag = dragEvent.getClipData().getItemAt(3)
                                         .getText().toString();
 
                                 removeAppFromTab(appIndex, tabTag);
 
                                 // add it to the new tab
-                                String app_name = dragEvent.getClipData().getItemAt(0).getText().toString();
+                                String packageName = dragEvent.getClipData().getItemAt(0).getText().toString();
+                                String activityName = dragEvent.getClipData().getItemAt(1).getText().toString();
                                 //TODO: IMPORTANT. Fix this line.
-                                //dropAppInTab(app_name);
+                                dropAppInTab(new AppTable(null, packageName, activityName, null));
                             }
                         }
                         break;

--- a/app/src/main/java/com/launcher/silverfish/launcher/homescreen/HomeScreenFragment.java
+++ b/app/src/main/java/com/launcher/silverfish/launcher/homescreen/HomeScreenFragment.java
@@ -236,7 +236,7 @@ public class HomeScreenFragment extends Fragment  {
 
             // load the app icon in an async task
             ImageView im = (ImageView)convertView.findViewById(R.id.item_app_icon);
-            Utils.loadAppIconAsync(mPacMan, app.packageName.toString(), im);
+            Utils.loadAppIconAsync(mPacMan, app, im);
 
             TextView tv = (TextView)convertView.findViewById(R.id.item_app_label);
             tv.setText(app.label);

--- a/app/src/main/java/com/launcher/silverfish/launcher/homescreen/HomeScreenFragment.java
+++ b/app/src/main/java/com/launcher/silverfish/launcher/homescreen/HomeScreenFragment.java
@@ -27,7 +27,7 @@ import android.content.ClipData;
 import android.content.ClipDescription;
 import android.content.ComponentName;
 import android.content.Intent;
-import android.content.pm.ApplicationInfo;
+import android.content.pm.ActivityInfo;
 import android.content.pm.PackageManager;
 import android.os.Build;
 import android.os.Bundle;
@@ -174,10 +174,10 @@ public class HomeScreenFragment extends Fragment  {
 
     private boolean addAppToView(ShortcutTable shortcut) {
         try {
-            ApplicationInfo appInfo = mPacMan.getApplicationInfo(
-                    shortcut.getPackageName(), PackageManager.GET_META_DATA);
+            ActivityInfo activityInfo = mPacMan.getActivityInfo(
+                    new ComponentName(shortcut.getPackageName(), shortcut.getActivityName()), PackageManager.GET_META_DATA);
             AppDetail appDetail = new AppDetail();
-            appDetail.label = mPacMan.getApplicationLabel(appInfo);
+            appDetail.label = activityInfo.loadLabel(mPacMan);
 
             // load the icon later in an async task
             appDetail.icon = null;

--- a/app/src/main/java/com/launcher/silverfish/launcher/homescreen/HomeScreenFragment.java
+++ b/app/src/main/java/com/launcher/silverfish/launcher/homescreen/HomeScreenFragment.java
@@ -121,8 +121,10 @@ public class HomeScreenFragment extends Fragment  {
             public void OnShortcutAdd(String appName) {
                 // Insert it into the database and get the row id
                 // TODO: Check if an error has occurred while inserting into database.
-                if (sqlHelper.canAddShortcut(appName)) {
-                    long appId = sqlHelper.addShortcut(appName);
+                // TODO: IMPORTANT. Figure out a way to get the corresponding activityName here.
+                ShortcutTable shortcutTable = new ShortcutTable(null, appName, null);
+                if (sqlHelper.canAddShortcut(shortcutTable)) {
+                    long appId = sqlHelper.addShortcut(shortcutTable);
 
                     // Create shortcut and add it
                     ShortcutTable shortcut = new ShortcutTable();

--- a/app/src/main/java/com/launcher/silverfish/launcher/homescreen/HomeScreenFragment.java
+++ b/app/src/main/java/com/launcher/silverfish/launcher/homescreen/HomeScreenFragment.java
@@ -49,6 +49,7 @@ import android.widget.Toast;
 import com.launcher.silverfish.R;
 import com.launcher.silverfish.common.Constants;
 import com.launcher.silverfish.common.Utils;
+import com.launcher.silverfish.dbmodel.AppTable;
 import com.launcher.silverfish.dbmodel.ShortcutTable;
 import com.launcher.silverfish.launcher.App;
 import com.launcher.silverfish.launcher.LauncherActivity;
@@ -118,19 +119,14 @@ public class HomeScreenFragment extends Fragment  {
         ((LauncherActivity)getActivity())
                 .setFragShortcutAddListenerRefreshListener(new ShortcutAddListener() {
             @Override
-            public void OnShortcutAdd(String appName) {
+            public void OnShortcutAdd(AppTable appTable) {
                 // Insert it into the database and get the row id
                 // TODO: Check if an error has occurred while inserting into database.
-                // TODO: IMPORTANT. Figure out a way to get the corresponding activityName here.
-                ShortcutTable shortcutTable = new ShortcutTable(null, appName, null);
+                ShortcutTable shortcutTable = new ShortcutTable(null, appTable.getPackageName(),
+                        appTable.getActivityName());
                 if (sqlHelper.canAddShortcut(shortcutTable)) {
-                    long appId = sqlHelper.addShortcut(shortcutTable);
-
-                    // Create shortcut and add it
-                    ShortcutTable shortcut = new ShortcutTable();
-                    shortcut.setPackageName(appName);
-                    shortcut.setId(appId);
-                    if (addAppToView(shortcut)) {
+                    sqlHelper.addShortcut(shortcutTable);
+                    if (addAppToView(shortcutTable)) {
                         updateShortcuts();
                     }
                 }
@@ -187,6 +183,7 @@ public class HomeScreenFragment extends Fragment  {
             appDetail.icon = null;
 
             appDetail.packageName = shortcut.getPackageName();
+            appDetail.activityName = shortcut.getActivityName();
             appDetail.id = shortcut.getId();
 
             appsList.add(appDetail);

--- a/app/src/main/java/com/launcher/silverfish/launcher/homescreen/ShortcutAddListener.java
+++ b/app/src/main/java/com/launcher/silverfish/launcher/homescreen/ShortcutAddListener.java
@@ -19,9 +19,11 @@
 
 package com.launcher.silverfish.launcher.homescreen;
 
+import com.launcher.silverfish.dbmodel.AppTable;
+
 /**
  * Used for communication between the launcher activity and the home screen fragment.
  */
 public interface ShortcutAddListener {
-    void OnShortcutAdd(String appName);
+    void OnShortcutAdd(AppTable appTable);
 }

--- a/app/src/main/java/com/launcher/silverfish/models/AppDetail.java
+++ b/app/src/main/java/com/launcher/silverfish/models/AppDetail.java
@@ -24,7 +24,8 @@ public class AppDetail {
     public CharSequence label;
     public CharSequence packageName;
     public CharSequence activityName;
-
+    public CharSequence intentUri; // for launcher shortcuts created by for example
+    // file managers which open a specific directory.
     public Drawable icon;
     public long id;
 }

--- a/app/src/main/java/com/launcher/silverfish/models/AppDetail.java
+++ b/app/src/main/java/com/launcher/silverfish/models/AppDetail.java
@@ -23,6 +23,8 @@ import android.graphics.drawable.Drawable;
 public class AppDetail {
     public CharSequence label;
     public CharSequence packageName;
+    public CharSequence activityName;
+
     public Drawable icon;
     public long id;
 }

--- a/app/src/main/java/com/launcher/silverfish/sqlite/LauncherSQLiteHelper.java
+++ b/app/src/main/java/com/launcher/silverfish/sqlite/LauncherSQLiteHelper.java
@@ -108,9 +108,11 @@ public class LauncherSQLiteHelper {
     }
 
     public boolean canAddShortcut(ShortcutTable shortcutTable) {
-        return mSession.getShortcutTableDao().queryBuilder()
-                .where(ShortcutTableDao.Properties.ActivityName.eq(shortcutTable.getActivityName()))
+        boolean ret = mSession.getShortcutTableDao().queryBuilder()
+                .where(ShortcutTableDao.Properties.ActivityName.eq(shortcutTable.getActivityName()),
+                        ShortcutTableDao.Properties.PackageName.eq(shortcutTable.getPackageName()))
                 .unique() == null;
+        return ret;
     }
 
     public long addShortcut(ShortcutTable shortcutTable) {

--- a/app/src/main/java/com/launcher/silverfish/sqlite/LauncherSQLiteHelper.java
+++ b/app/src/main/java/com/launcher/silverfish/sqlite/LauncherSQLiteHelper.java
@@ -120,7 +120,8 @@ public class LauncherSQLiteHelper {
                 .unique() == null;
         } else {
             return mSession.getShortcutTableDao().queryBuilder()
-                    .where(commonCondition)
+                    .where(commonCondition,
+                            ShortcutTableDao.Properties.IntentUri.isNull())
                     .unique() == null;
         }
     }

--- a/app/src/main/java/com/launcher/silverfish/sqlite/LauncherSQLiteHelper.java
+++ b/app/src/main/java/com/launcher/silverfish/sqlite/LauncherSQLiteHelper.java
@@ -30,6 +30,7 @@ import com.launcher.silverfish.launcher.App;
 
 import org.greenrobot.greendao.DaoException;
 import org.greenrobot.greendao.query.QueryBuilder;
+import org.greenrobot.greendao.query.WhereCondition;
 
 import java.util.List;
 
@@ -108,11 +109,20 @@ public class LauncherSQLiteHelper {
     }
 
     public boolean canAddShortcut(ShortcutTable shortcutTable) {
-        boolean ret = mSession.getShortcutTableDao().queryBuilder()
-                .where(ShortcutTableDao.Properties.ActivityName.eq(shortcutTable.getActivityName()),
-                        ShortcutTableDao.Properties.PackageName.eq(shortcutTable.getPackageName()))
+        WhereCondition commonCondition = mSession.getShortcutTableDao().queryBuilder().and(
+                ShortcutTableDao.Properties.ActivityName.eq(shortcutTable.getActivityName()),
+                ShortcutTableDao.Properties.PackageName.eq(shortcutTable.getPackageName())
+        );
+        if (shortcutTable.getIntentUri() != null) {
+            return mSession.getShortcutTableDao().queryBuilder()
+                    .where(commonCondition,
+                            ShortcutTableDao.Properties.IntentUri.eq(shortcutTable.getIntentUri()))
                 .unique() == null;
-        return ret;
+        } else {
+            return mSession.getShortcutTableDao().queryBuilder()
+                    .where(commonCondition)
+                    .unique() == null;
+        }
     }
 
     public long addShortcut(ShortcutTable shortcutTable) {

--- a/app/src/main/java/com/launcher/silverfish/sqlite/LauncherSQLiteHelper.java
+++ b/app/src/main/java/com/launcher/silverfish/sqlite/LauncherSQLiteHelper.java
@@ -31,11 +31,10 @@ import com.launcher.silverfish.launcher.App;
 import org.greenrobot.greendao.DaoException;
 import org.greenrobot.greendao.query.QueryBuilder;
 
-import java.util.LinkedList;
 import java.util.List;
-import java.util.Map;
 
 public class LauncherSQLiteHelper {
+
     private DaoSession mSession;
 
     public LauncherSQLiteHelper(App app) {
@@ -76,31 +75,22 @@ public class LauncherSQLiteHelper {
                 .list();
     }
 
-    public List<AppTable> getAllApps() {
-        return mSession.getAppTableDao().loadAll();
-    }
-
-    public boolean containsApp(String packageName) {
+    /*  Looks like this is unused. Commenting out (YAGNI).
+        public List<AppTable> getAllApps() {
+            return mSession.getAppTableDao().loadAll();
+        }
+    */
+    public boolean containsApp(String activityName) {
         return mSession.getAppTableDao().queryBuilder()
-                .where(AppTableDao.Properties.PackageName.eq(packageName))
+                .where(AppTableDao.Properties.ActivityName.eq(activityName))
                 .unique() != null;
     }
 
-    public void addAppToTab(AppTable appTable, long tabId) {
-        appTable.setId(null);
-        appTable.setTabId(tabId);
+    public void addAppToTab(AppTable appTable) {
         mSession.getAppTableDao().insert(appTable);
     }
 
-    public void addAppsToTab(Map<AppTable, Long> pkg_categoryId) {
-        List<AppTable> apps = new LinkedList<>();
-        for (Map.Entry<AppTable, Long> entry : pkg_categoryId.entrySet()) {
-            AppTable appTable = entry.getKey();
-            long tabId = entry.getValue();
-            appTable.setId(null);
-            appTable.setTabId(tabId);
-            apps.add(appTable);
-        }
+    public void addAppsToTab(List<AppTable> apps) {
         mSession.getAppTableDao().insertInTx(apps);
     }
 

--- a/app/src/main/java/com/launcher/silverfish/sqlite/LauncherSQLiteHelper.java
+++ b/app/src/main/java/com/launcher/silverfish/sqlite/LauncherSQLiteHelper.java
@@ -104,9 +104,9 @@ public class LauncherSQLiteHelper {
         mSession.getAppTableDao().insertInTx(apps);
     }
 
-    public void removeAppFromTab(AppTable appTable, long tabId) {
+    public void removeAppFromTab(AppTable appTable) {
         QueryBuilder qb = mSession.getAppTableDao().queryBuilder();
-        AppTable app = (AppTable)qb.where(qb.and(AppTableDao.Properties.TabId.eq(tabId),
+        AppTable app = (AppTable) qb.where(qb.and(AppTableDao.Properties.TabId.eq(appTable.getTabId()),
                 AppTableDao.Properties.ActivityName.eq(appTable.getActivityName()))).unique();
 
         if (app != null)

--- a/app/src/main/java/com/launcher/silverfish/sqlite/LauncherSQLiteHelper.java
+++ b/app/src/main/java/com/launcher/silverfish/sqlite/LauncherSQLiteHelper.java
@@ -86,22 +86,28 @@ public class LauncherSQLiteHelper {
                 .unique() != null;
     }
 
-    public void addAppToTab(String packageName, long tabId) {
-        mSession.getAppTableDao().insert(new AppTable(null, packageName, tabId));
+    public void addAppToTab(AppTable appTable, long tabId) {
+        appTable.setId(null);
+        appTable.setTabId(tabId);
+        mSession.getAppTableDao().insert(appTable);
     }
 
-    public void addAppsToTab(Map<String, Long> pkg_categoryId) {
+    public void addAppsToTab(Map<AppTable, Long> pkg_categoryId) {
         List<AppTable> apps = new LinkedList<>();
-        for (Map.Entry<String, Long> entry : pkg_categoryId.entrySet()) {
-            apps.add(new AppTable(null, entry.getKey(), entry.getValue()));
+        for (Map.Entry<AppTable, Long> entry : pkg_categoryId.entrySet()) {
+            AppTable appTable = entry.getKey();
+            long tabId = entry.getValue();
+            appTable.setId(null);
+            appTable.setTabId(tabId);
+            apps.add(appTable);
         }
         mSession.getAppTableDao().insertInTx(apps);
     }
 
-    public void removeAppFromTab(String packageName, long tabId) {
+    public void removeAppFromTab(AppTable appTable, long tabId) {
         QueryBuilder qb = mSession.getAppTableDao().queryBuilder();
         AppTable app = (AppTable)qb.where(qb.and(AppTableDao.Properties.TabId.eq(tabId),
-                AppTableDao.Properties.PackageName.eq(packageName))).unique();
+                AppTableDao.Properties.ActivityName.eq(appTable.getActivityName()))).unique();
 
         if (app != null)
             mSession.getAppTableDao().delete(app);
@@ -111,14 +117,15 @@ public class LauncherSQLiteHelper {
         mSession.getAppTableDao().deleteInTx(apps);
     }
 
-    public boolean canAddShortcut(String packageName) {
+    public boolean canAddShortcut(ShortcutTable shortcutTable) {
         return mSession.getShortcutTableDao().queryBuilder()
-                .where(ShortcutTableDao.Properties.PackageName.eq(packageName))
+                .where(ShortcutTableDao.Properties.ActivityName.eq(shortcutTable.getActivityName()))
                 .unique() == null;
     }
 
-    public long addShortcut(String packageName) {
-        return mSession.getShortcutTableDao().insert(new ShortcutTable(null, packageName));
+    public long addShortcut(ShortcutTable shortcutTable) {
+        shortcutTable.setId(null);
+        return mSession.getShortcutTableDao().insert(shortcutTable);
     }
 
     public long getShortcutId(String packageName) {

--- a/app/src/main/java/com/launcher/silverfish/utils/PackagesCategories.java
+++ b/app/src/main/java/com/launcher/silverfish/utils/PackagesCategories.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.content.pm.ResolveInfo;
 
 import com.launcher.silverfish.R;
+import com.launcher.silverfish.dbmodel.AppTable;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -93,45 +94,48 @@ public final class PackagesCategories {
 
     //region Set each package category
 
-    public static HashMap<String, Long> setCategories(Context ctx,
-                                                         List<ResolveInfo> activities)
+    public static HashMap<AppTable, Long> setCategories(Context ctx,
+                                                        List<ResolveInfo> activities)
     {
         return setCategories(activities, getPredefinedCategories(ctx), getKeywords());
     }
 
-    public static HashMap<String, Long> setCategories(List<ResolveInfo> activities,
-                                                         HashMap<String, String> categories,
-                                                         HashMap<String, String[]> keywords)
+    public static HashMap<AppTable, Long> setCategories(List<ResolveInfo> activities,
+                                                        HashMap<String, String> categories,
+                                                        HashMap<String, String[]> keywords)
     {
-        HashMap<String, Long> pkg_categoryId = new HashMap<>();
-        String pkg;
+        HashMap<AppTable, Long> app_categoryId = new HashMap<>();
+        AppTable appTable = new AppTable();
         long categoryId;
 
         for (int i = 0; i < activities.size(); i++) {
             ResolveInfo ri = activities.get(i);
-            pkg = ri.activityInfo.packageName;
+            String activityName = ri.activityInfo.name;
+            String packageName = ri.activityInfo.packageName;
+            appTable.setActivityName(activityName);
+            appTable.setPackageName(packageName);
 
 
-            if (categories.containsKey(pkg)) {
-                categoryId = getCategoryId(categories.get(pkg));
+            if (categories.containsKey(packageName)) {
+                categoryId = getCategoryId(categories.get(packageName));
 
                 // Only add if not default
                 if (categoryId > 1) {
-                    pkg_categoryId.put(pkg, categoryId);
+                    app_categoryId.put(appTable, categoryId);
                 }
             }
             // Intelligent fallback: Try to guess the category
             else {
-                pkg = pkg.toLowerCase();
+                String _packageName = packageName.toLowerCase();
                 for (String key : keywords.keySet()) {
-                    if (containsKeyword(pkg, keywords.get(key))) {
-                        pkg_categoryId.put(pkg, getCategoryId(key));
+                    if (containsKeyword(_packageName, keywords.get(key))) {
+                        app_categoryId.put(appTable, getCategoryId(key));
                     }
                 }
             }
         }
 
-        return pkg_categoryId;
+        return app_categoryId;
     }
 
     //endregion

--- a/app/src/main/java/com/launcher/silverfish/utils/PackagesCategories.java
+++ b/app/src/main/java/com/launcher/silverfish/utils/PackagesCategories.java
@@ -10,6 +10,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 
@@ -94,24 +95,23 @@ public final class PackagesCategories {
 
     //region Set each package category
 
-    public static HashMap<AppTable, Long> setCategories(Context ctx,
-                                                        List<ResolveInfo> activities)
+    public static List<AppTable> setCategoriesForAppTable(Context ctx,
+                                                          List<ResolveInfo> activities)
     {
-        return setCategories(activities, getPredefinedCategories(ctx), getKeywords());
+        return setCategoriesForAppTable(activities, getPredefinedCategories(ctx), getKeywords());
     }
 
-    public static HashMap<AppTable, Long> setCategories(List<ResolveInfo> activities,
-                                                        HashMap<String, String> categories,
-                                                        HashMap<String, String[]> keywords)
+    public static List<AppTable> setCategoriesForAppTable(List<ResolveInfo> activities,
+                                                          HashMap<String, String> categories,
+                                                          HashMap<String, String[]> keywords)
     {
-        HashMap<AppTable, Long> app_categoryId = new HashMap<>();
-        AppTable appTable = new AppTable();
+        List<AppTable> apps = new ArrayList<>();
         long categoryId;
-
-        for (int i = 0; i < activities.size(); i++) {
-            ResolveInfo ri = activities.get(i);
+        for (ResolveInfo ri : activities) {
             String activityName = ri.activityInfo.name;
             String packageName = ri.activityInfo.packageName;
+
+            AppTable appTable = new AppTable();
             appTable.setActivityName(activityName);
             appTable.setPackageName(packageName);
 
@@ -121,7 +121,8 @@ public final class PackagesCategories {
 
                 // Only add if not default
                 if (categoryId > 1) {
-                    app_categoryId.put(appTable, categoryId);
+                    appTable.setTabId(categoryId);
+                    apps.add(appTable);
                 }
             }
             // Intelligent fallback: Try to guess the category
@@ -129,13 +130,15 @@ public final class PackagesCategories {
                 String _packageName = packageName.toLowerCase();
                 for (String key : keywords.keySet()) {
                     if (containsKeyword(_packageName, keywords.get(key))) {
-                        app_categoryId.put(appTable, getCategoryId(key));
+                        appTable.setTabId(getCategoryId(key));
+                        apps.add(appTable);
+                        break;
                     }
                 }
             }
         }
 
-        return app_categoryId;
+        return apps;
     }
 
     //endregion


### PR DESCRIPTION
AppTable is updated to store activity name in addition to package name.
Updated code to load labels and icons based on activity name instead of package name
Add to homescreen popup now appears as expected.

Todo:
Homescreen shortcuts added by other apps, like file managers are not loaded until Silverfish is restarted.
The labels and icons of those shortcuts are the same as those of the main app. 
For example, it is 'File Explorer' instead of 'My Folder', when I add a shortcut to My Folder through 
the File Explorer app. 
