### PR TITLE
 Fixed: Pressing home key doesn't bring back launcher in some cases.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -17,7 +17,8 @@
         <activity
             android:name=".launcher.LauncherActivity"
             android:theme="@style/AppTheme"
-            android:label="Silverfish Launcher">
+            android:label="Silverfish Launcher"
+            android:excludeFromRecents="true">
             <!--android:theme="@android:style/Theme.Wallpaper.NoTitleBar"-->
 
             <intent-filter>

--- a/app/src/main/java/com/launcher/silverfish/launcher/appdrawer/AppArrayAdapter.java
+++ b/app/src/main/java/com/launcher/silverfish/launcher/appdrawer/AppArrayAdapter.java
@@ -3,7 +3,6 @@ package com.launcher.silverfish.launcher.appdrawer;
 import android.app.Activity;
 import android.content.ClipData;
 import android.content.ClipDescription;
-import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
@@ -113,8 +112,7 @@ public class AppArrayAdapter extends ArrayAdapter<AppDetail> {
                         e.printStackTrace();
                     }
                 } else {
-                    i.setAction(Intent.ACTION_MAIN);
-                    i.setComponent(new ComponentName(app.packageName.toString(), app.activityName.toString()));
+                    i = mPackageManager.getLaunchIntentForPackage(app.packageName.toString());
                 }
                 if (i != null) {
                     // Sanity check (application may have been uninstalled)


### PR DESCRIPTION
When some apps are opened from the app drawer, pressing the home key didn't bring back the launcher. SoundCloud and Materialistic are the apps I encountered with this behavior.
Android somehow thinks that the activity we are launching is actually part of Silverfish.
The affected apps are not even shown in the Recents list, just like the launcher is not shown.
Pressing back button works fine.

This PR fixes the above issue.